### PR TITLE
Declare `vm_service` as a dev dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,8 +13,8 @@ dev_dependencies:
   mockito: ^5.4.0
   test: ^1.21.0
   total_lints:
+  vm_service: ^13.0.0
 
 dependencies:
   async: ^2.11.0
   meta: ^1.9.0
-  vm_service: ^13.0.0


### PR DESCRIPTION
A quick adjustment: since `vm_service` is only used in tests, there's no need to make all users of `autoclose` depend on it.